### PR TITLE
Small benchmark.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,27 @@
+package fnv_test
+
+import (
+	theirlib "hash/fnv"
+	"testing"
+
+	ourlib "github.com/realzeitmedia/fnv"
+)
+
+const (
+	src = "hello world"
+)
+
+func BenchmarkStringsStdlib(b *testing.B) {
+	h := theirlib.New64a()
+	for i := 0; i < b.N; i++ {
+		h.Write([]byte(src))
+	}
+	_ = h.Sum64()
+}
+
+func BenchmarkStrings(b *testing.B) {
+	h := ourlib.New()
+	for i := 0; i < b.N; i++ {
+		h = ourlib.Add(h, src)
+	}
+}


### PR DESCRIPTION
I'd have preferred to actually do something with the hash, but that's kind of hard... Should we compare to the result of the other lib?

```
$ go test -bench=.
PASS
BenchmarkStringsStdlib-4    20000000            85.6 ns/op
BenchmarkStrings-4          50000000            32.9 ns/op
ok      github.com/realzeitmedia/fnv    3.500s
```
